### PR TITLE
Bug fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2081,6 +2081,15 @@
             "yallist": "^3.0.2"
           }
         },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
@@ -2631,6 +2640,17 @@
         "mkdirp": "^0.5.1",
         "rimraf": "^2.5.4",
         "run-queue": "^1.0.0"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "copy-descriptor": {
@@ -3024,6 +3044,15 @@
           "dev": true,
           "requires": {
             "path-is-inside": "^1.0.2"
+          }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
           }
         }
       }
@@ -4102,6 +4131,17 @@
         "flatted": "^2.0.0",
         "rimraf": "2.6.3",
         "write": "1.0.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "flatted": {
@@ -6155,6 +6195,15 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -6399,6 +6448,15 @@
           "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.3.tgz",
           "integrity": "sha512-QgrPRJfE+riq5TPZMcHZOtm8c6K/yYrMbKIoRfapfiGLxS8OTeIfRhUGW5LU7MlRa52KOAGCfUNruqLrIBvWZw==",
           "dev": true
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
         },
         "source-map": {
           "version": "0.6.1",
@@ -7080,6 +7138,17 @@
         "mkdirp": "^0.5.1",
         "rimraf": "^2.5.4",
         "run-queue": "^1.0.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "ms": {
@@ -7707,6 +7776,15 @@
             "yallist": "^3.0.2"
           }
         },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
@@ -8182,6 +8260,17 @@
             "pify": "^2.0.0",
             "pinkie-promise": "^2.0.0",
             "rimraf": "^2.2.8"
+          },
+          "dependencies": {
+            "rimraf": {
+              "version": "2.7.1",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+              "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+              "dev": true,
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            }
           }
         },
         "globby": {
@@ -8233,6 +8322,17 @@
             "rimraf": "^2.5.2",
             "semver": "^5.3.0",
             "xml2js": "^0.4.17"
+          },
+          "dependencies": {
+            "rimraf": {
+              "version": "2.7.1",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+              "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+              "dev": true,
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            }
           }
         }
       }
@@ -8736,9 +8836,9 @@
       "dev": true
     },
     "rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.0.tgz",
+      "integrity": "sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==",
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
@@ -8876,6 +8976,15 @@
         "xml2js": "^0.4.17"
       },
       "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
         "tmp": {
           "version": "0.0.30",
           "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.30.tgz",
@@ -10610,6 +10719,17 @@
             "pify": "^2.0.0",
             "pinkie-promise": "^2.0.0",
             "rimraf": "^2.2.8"
+          },
+          "dependencies": {
+            "rimraf": {
+              "version": "2.7.1",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+              "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+              "dev": true,
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            }
           }
         },
         "get-caller-file": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6692,9 +6692,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.clonedeep": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "docker:open:mac": "echo Trying to launch on MacOS && sleep 2 && URL=http://localhost:$npm_package_config_imagePort && open $URL",
     "docker:debugmessage": "echo Docker Debug Completed Successfully! Hit Ctrl+C to terminate log tailing.",
     "predocker:debug": "run-s -c docker:build docker:run",
-    "docker:debug": "run-s -cs docker:open:win docker:open:mac docker:debugmessage docker:taillogs"
+    "docker:debug": "run-s -cs docker:open:win docker:open:mac docker:debugmessage docker:taillogs",
+    "refresh": "rimraf ./node_modules/ && npm install"
   },
   "private": true,
   "dependencies": {
@@ -86,10 +87,11 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^1.18.2",
     "protractor": "~5.4.0",
+    "rimraf": "^3.0.0",
     "ts-node": "~7.0.0",
     "tslint": "~5.15.0",
-    "uswds": "^2.0.3",
-    "typescript": "~3.4.3"
+    "typescript": "~3.4.3",
+    "uswds": "^2.0.3"
   },
   "importSort": {
     ".ts, .tsx": {

--- a/src/app/admin/manage-categories/manage-categories.component.html
+++ b/src/app/admin/manage-categories/manage-categories.component.html
@@ -2,7 +2,7 @@
   <mat-card>
     <mat-card-title>Add/Edit Category</mat-card-title>
     <tcp-category-form [category]="categoryToEdit"
-      (addCategory)="onSubmitCategory($event)">
+      (submitCategory)="onSubmitCategory($event)">
     </tcp-category-form>
   </mat-card>
   <mat-card>

--- a/src/app/admin/manage-categories/manage-categories.component.ts
+++ b/src/app/admin/manage-categories/manage-categories.component.ts
@@ -48,14 +48,15 @@ export class ManageCategoriesComponent {
 
   onSubmitCategory(category: ICategory) {
     this.categoryToEdit = null
+    console.log(category)
     if (category.id) {
       this.categoryService
         .update(category)
-        .subscribe(this.snackBarService.observerFor<ICategory>('Create Category'))
+        .subscribe(this.snackBarService.observerFor<ICategory>('Update Category'))
     } else {
       this.categoryService
         .create(category)
-        .subscribe(this.snackBarService.observerFor<ICategory>('Update Category'))
+        .subscribe(this.snackBarService.observerFor<ICategory>('Add Category'))
     }
   }
 }

--- a/src/app/admin/manage-skills/skill-form/skill-form.component.html
+++ b/src/app/admin/manage-skills/skill-form/skill-form.component.html
@@ -15,6 +15,8 @@
         <mat-option *ngFor="let category of categories$ | async" [value]="category">
           {{ category.name | titlecase }}</mat-option>
       </mat-select>
+      <mat-error *ngIf="formGroup.get('category').hasError('required')">
+        {{ 'Category' | requiredMessage }}</mat-error>
     </mat-form-field>
   </div>
   <div>

--- a/src/app/admin/manage-skills/skill-form/skill-form.component.ts
+++ b/src/app/admin/manage-skills/skill-form/skill-form.component.ts
@@ -9,7 +9,7 @@ import {
 } from '@angular/core'
 import { FormBuilder, FormGroup, Validators } from '@angular/forms'
 import { Observable } from 'rxjs'
-import { map } from 'rxjs/operators'
+import { map, take } from 'rxjs/operators'
 
 import { BaseForm } from '../../../abstracts/base-form.class'
 import { ICategory, ISkill } from '../../../models/skill.interface'
@@ -39,7 +39,12 @@ export class SkillFormComponent extends BaseForm implements OnInit, OnChanges {
   ngOnChanges(changes: SimpleChanges) {
     if (hasChanged(changes.skill)) {
       if (this.skill) {
-        this.formGroup.patchValue(this.skill)
+        const skill: ISkill = {...changes.skill.currentValue}
+        // take(1) auto-completes the observable, no need to unsubscribe
+        this.categories$.pipe(take(1)).subscribe(categories => {
+          skill.category = categories.find(c => c.id === skill.category.id)
+          this.formGroup.patchValue(skill)
+        })
       } else {
         this.formGroup.reset()
       }

--- a/src/app/services/abstract/base-crud.service.ts
+++ b/src/app/services/abstract/base-crud.service.ts
@@ -4,47 +4,49 @@ import { BehaviorSubject, Observable } from 'rxjs'
 import { tap } from 'rxjs/operators'
 
 import { environment } from '../../../environments/environment'
+import { IBaseItem } from '../../models/base-item.interface'
 
-export interface IBaseCrudService<T> {
-  readonly list: BehaviorSubject<T[]>
+export interface IBaseCrudService<I extends IBaseItem> {
+  readonly list: BehaviorSubject<I[]>
   endpoint: string
-  fetch(): Observable<T[]>
-  getById(id: number): Observable<T>
-  create(item: T): Observable<T>
-  update(item: T): Observable<T>
-  delete(id: number): Observable<T>
+  fetch(): Observable<I[]>
+  getById(id: number): Observable<I>
+  create(item: I): Observable<I>
+  update(item: I): Observable<I>
+  delete(id: number): Observable<I>
 }
 
-export abstract class BaseCrudService<T> implements IBaseCrudService<T>, Resolve<T[]> {
-  readonly list = new BehaviorSubject<T[]>([])
+export abstract class BaseCrudService<I extends IBaseItem>
+  implements IBaseCrudService<I>, Resolve<I[]> {
+  readonly list = new BehaviorSubject<I[]>([])
 
   abstract endpoint: string
 
   constructor(protected http: HttpClient) {}
 
-  fetch(): Observable<T[]> {
+  fetch(): Observable<I[]> {
     return this.http
-      .get<T[]>(`${environment.api}${this.endpoint}`)
-      .pipe(tap((items: T[]) => this.list.next(items)))
+      .get<I[]>(`${environment.api}${this.endpoint}`)
+      .pipe(tap((items: I[]) => this.list.next(items)))
   }
 
-  getById(id: number): Observable<T> {
-    return this.http.get<T>(`${environment.api}${this.endpoint}/${id}`)
+  getById(id: number): Observable<I> {
+    return this.http.get<I>(`${environment.api}${this.endpoint}/${id}`)
   }
 
-  create(item: T): Observable<T> {
-    return this.http.post<T>(`${environment.api}${this.endpoint}`, item)
+  create(item: I): Observable<I> {
+    return this.http.post<I>(`${environment.api}${this.endpoint}`, item).pipe(tap(() => this.fetch().subscribe()))
   }
 
-  update(item: T): Observable<T> {
-    return this.http.post<T>(`${environment.api}${this.endpoint}`, item)
+  update(item: I): Observable<I> {
+    return this.http.put<I>(`${environment.api}${this.endpoint}${item.id}`, item).pipe(tap(() => this.fetch().subscribe()))
   }
 
-  delete(id: number): Observable<T> {
-    return this.http.delete<T>(`${environment.api}${this.endpoint}/${id}`)
+  delete(id: number): Observable<I> {
+    return this.http.delete<I>(`${environment.api}${this.endpoint}${id}`).pipe(tap(() => this.fetch().subscribe()))
   }
 
-  resolve(): Observable<T[]> {
+  resolve(): Observable<I[]> {
     return this.fetch()
   }
 }


### PR DESCRIPTION
1. Updating skills/categories was failing because we were sending a POST which is no longer allowed - switched to a PUT
1. When editing a skill, the Category drop-down was not populating correctly.
1. The Add/Update category button was not working due to a wiring issue, and the toast confirmation was backwards (mentioned  your update was successful when creating, etc) 
1. It'd be nice if the BaseCrud service had CrudServices refresh their cache on Create/Update or Delete actions.  So, now they do that.
1. We didn't have an `npm run refresh` script to nuke node_modules and re-install, so now we do.

